### PR TITLE
Handling consent mechanism + refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This library does not require any API keys, with the attached maximum quotas, bu
 The library works as long as YouTube keeps its web page layout the same. Therefore, there is **no guarantee** that this library will work at all times.
 If this library should not work at some point, please create an issue and let me know so that I can take a look into it. Pull requests are also welcomed in this case.
 
+## Difference between 3.x and 4.x
+The `setCookie` option on `getComments`' `payload` argument is no longer available, as all cookies are now necessary for the comments' request to return any data
+
 ## Installation
 `npm install yt-comment-scraper --save`
 
@@ -24,14 +27,12 @@ Returns a list of objects containing comments from the next page of the video.
 - payload (Object) (Required) - An object containing the various options
   - videoId (String) (Required) - The video ID to grab comments from
   - sortByNewest (Boolean) (Default: `false`) - Grabs newest comments when `true`. Grabs top comments when `false`
-  - setCookie (Boolean) (Default: `true`) - Sets a cookie internally when grabbing comments. May not be needed depending on your environment
   - continuation (Optional) - The token from a previous call to continue grabbing comments
 
 ```javascript
 const payload = {
   videoId: videoId, // Required
   sortByNewest: sortByNewest,
-  setCookie: setCookie,
   continuation: continuation
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-comment-scraper",
-  "version": "1.3.11",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,24 +13,19 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
-    "html2json": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html2json/-/html2json-1.0.2.tgz",
-      "integrity": "sha1-ydbSAvplQCOGwgKzRc9RvOgO0e8="
-    },
     "node-html-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.0.2.tgz",
-      "integrity": "sha512-N2000Ho9dkabvRZcyiwm6zOpdiAzxAxcJ0Z0WNoh/yXHG0YCuiK2WpNQfN+9vheLNY/h/It11Gk7uwT4QTfk9Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.2.1.tgz",
+      "integrity": "sha512-Vccqb62t6t7DkMVwqPQgb0NWO+gUMMDm+1X3LzqbtXLqjilCTtUYTlniKk08yuA1zIhEFVzu/dozpqs5KZbRFQ==",
       "requires": {
         "he": "1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-comment-scraper",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Scrapes the comments of any YouTube video without YouTube API access. Uses the default YouTube Ajax calls to get the comment data.",
   "main": "index.js",
   "scripts": {

--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -26,7 +26,7 @@ class HttpRequester {
       })
     }
 
-    async getVideoTokens(videoId, sortBy='top', setCookie=true) {
+    async getVideoTokens(videoId, sortBy='top') {
       try {
           const response =  await axios.get(baseURL+ "watch?v=" + videoId)
           const html_data = response.data

--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -72,12 +72,15 @@ class HttpRequester {
             this.cookie2 = response.headers["set-cookie"][0]+';'+response.headers["set-cookie"][1]+';'+response.headers["set-cookie"][2]
           }
 
-          const returnData = {
-            xsrf: xsrf,
-            continuation: continuationToken
-          }
+        for (const cookie of response.headers["set-cookie"]) {
+          const prunedCookie = cookie.match(/([A-Z0-9_]+=[^;]+);.+/)[1]
+          this.session.defaults.headers['cookie'].push(prunedCookie)
+        }
 
-          return returnData
+        return {
+          xsrf: xsrf,
+          continuation: continuationToken
+        }
       } catch (e) {
           return {
               error: true,

--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -2,18 +2,31 @@ const axios = require("axios")
 const baseURL = "https://www.youtube.com/"
 const ajaxURL = "comment_service_ajax"
 
+// Generates random integer (start and end inclusive)
+function random(start, end) {
+  return Math.floor(Math.random() * (end - start + 1)) + start
+}
+
 class HttpRequester {
-    async getVideoTokens(videoId, sortBy='top', setCookie=true) {
-      // cookie1 = GPS=1; path=/; domain=.youtube.com; expires=Thu, 17-Sep-2020 13:03:47 GMT  cookie2 = VISITOR_INFO1_LIVE=a9IsI_YF_U8; path=/; domain=.youtube.com; secure; expires=Tue, 16-Mar-2021 12:33:47 GMT; httponly; samesite=None
+    constructor() {
       this.session = axios.create({
-          baseURL: baseURL,
-          timeout: 10000,
-          headers: {
-            'X-YouTube-Client-Name': '1',
-            'X-YouTube-Client-Version': '2.20201202.06.01',
-            'accept-language': 'en-US,en;q=0.5'
-          }
+        baseURL: baseURL,
+        timeout: 10000,
+        headers: {
+          'X-YouTube-Client-Name': '1',
+          'X-YouTube-Client-Version': '2.20210331.06.00',
+          'accept-language': 'en-US,en;q=0.5',
+          // NOTE: This currently provides a CONSENT cookie to
+          // everyone, including non-European populations,
+          // making this cookie potentially fingerprintable
+          'cookie': [
+            `CONSENT=YES+cb.20210328-17-p0.en+FX+${random(100, 999)}`
+          ]
+        }
       })
+    }
+
+    async getVideoTokens(videoId, sortBy='top', setCookie=true) {
       try {
           const response =  await axios.get(baseURL+ "watch?v=" + videoId)
           const html_data = response.data

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -7,12 +7,6 @@ class CommentScraper {
         return Promise.reject('No video Id given')
       }
 
-      let setCookie = true
-
-      if (typeof (payload.setCookie) !== 'undefined') {
-        setCookie = payload.setCookie
-      }
-
       let xsrf
       let continuationToken
       const sortBy = payload.sortByNewest ? 'new' : 'top'
@@ -22,12 +16,12 @@ class CommentScraper {
         if (typeof payload.xsrf !== 'undefined') {
           xsrf = payload.xsrf
         } else {
-          const tokens = await requester.getVideoTokens(payload.videoId, sortBy, setCookie)
+          const tokens = await requester.getVideoTokens(payload.videoId, sortBy)
           xsrf = tokens.xsrf
         }
         continuationToken = payload.continuation
       } else {
-        const tokens = await requester.getVideoTokens(payload.videoId, sortBy, setCookie)
+        const tokens = await requester.getVideoTokens(payload.videoId, sortBy)
         xsrf = tokens.xsrf
         continuationToken = tokens.continuation
       }
@@ -62,7 +56,7 @@ class CommentScraper {
 
       const requester = new HttpRequester()
 
-      const tokens = await requester.getVideoTokens(videoId, 'top', false)
+      const tokens = await requester.getVideoTokens(videoId, 'top')
       const xsrf = tokens.xsrf
 
       const commentsPayload = {

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -16,7 +16,7 @@ class CommentScraper {
       let xsrf
       let continuationToken
       const sortBy = payload.sortByNewest ? 'new' : 'top'
-      const requester = new HttpRequester(false, true)
+      const requester = new HttpRequester()
 
       if (typeof payload.continuation !== 'undefined') {
         if (typeof payload.xsrf !== 'undefined') {
@@ -60,8 +60,7 @@ class CommentScraper {
         return Promise.reject('No video Id given')
       }
 
-      let continuationToken
-      const requester = new HttpRequester(false, true)
+      const requester = new HttpRequester()
 
       const tokens = await requester.getVideoTokens(videoId, 'top', false)
       const xsrf = tokens.xsrf


### PR DESCRIPTION
Closes FreeTubeApp/FreeTube#1157

Google has applied a consent mechanism to the website that makes it so that it shows certain users (as far as I can tell, mainly European ones) a form that requests consent regarding cookies, among other things.
___
This consent is tracked in the form of a **CONSENT cookie**.
Without this cookie (and most additional ones, for some reason), this module cannot obtain any data from the comments internal API.

Fortunately, this CONSENT cookie can be easily generated and the remaining cookies are already being extracted from the initial `/watch` endpoint request.

This also makes the `setCookie` option functionality obsolete, as most cookies are now necessary to make the comments' request, so it's been stripped out.
___
Finally, the `HttpRequester` class has been slightly refactored for better maintenance and comprehension.