### PR TITLE
fix error when scraping videos with no comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-comment-scraper",
-  "version": "4.0.1",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -34,7 +34,7 @@ class CommentScraper {
 
       const commentPageResponse = await requester.requestCommentsPage(commentsPayload)
       const commentHtml = commentPageResponse.data.response.continuationContents.itemSectionContinuation
-      const commentData = htmlParser.parseCommentData(commentHtml.contents)
+      const commentData = (typeof commentHtml.contents !== 'undefined') ? htmlParser.parseCommentData(commentHtml.contents) : []
       const continuation = commentHtml.continuations
 
       let ctoken = null


### PR DESCRIPTION
Before this PR:
![image](https://user-images.githubusercontent.com/78101139/120553148-29f82000-c3c6-11eb-8f83-945cbb5716f6.png)

After this PR:
![image](https://user-images.githubusercontent.com/78101139/120553054-0a60f780-c3c6-11eb-894a-755e1e2e56e2.png)

Closes https://github.com/FreeTubeApp/FreeTube/issues/1386

Let me know if you'd rather an if else be used than a ternary operator.

FreeTube does this when I put the updated module into it:

![image](https://user-images.githubusercontent.com/78101139/120554898-5319b000-c3c8-11eb-8acd-6c58397023ba.png)
