### PR TITLE
Added option to add https agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,11 @@ Returns a list of objects containing comments from the next page of the video.
   - sortByNewest (Boolean) (Optional) - Grabs newest comments when `true`. Grabs top comments when `false`
   - continuation (String) (Optional) - The token from a previous call to continue grabbing comments
   - setCookie (Boolean) (Optional) - The flag should be set to true when cookies are not handled by your application (e.g. Electron) already 
-  - proxyData (Object) (Optional) - Defines Proxy data in an object like fashion. Allows to specify host, port, protocol, authentication 
+  - httpsAgent (Object) (Optional) - Defines Proxy data in an object like https proxy agent. Allows to specify host, port, protocol, authentication 
   ```javascript
-    const proxyData = {
-        host: String,       // Required
-        port: Number,       // Required
-        protocol: String,   // Required
-        auth: {             // Optional
-            username: String,   // Required if auth is used
-            password: String    // Required if auth is used
-        }     
-    } 
+    import HttpsProxyAgent from 'https-proxy-agent';
+    const proxy = 'http://127.0.0.1:10003';
+    const agent = HttpsProxyAgent(proxy);
   ```
 ```javascript
 const payload = {
@@ -45,11 +39,7 @@ const payload = {
   sortByNewest: sortByNewest,
   continuation: continuation,
   setCookie: false,
-  proxyData: {
-      host: '127.0.0.1',
-      port: 4000,
-      protocol: 'https'
-  }
+  httpsAgent: agent
 }
 
 ytcm.getComments(payload).then((data) =>{
@@ -93,9 +83,9 @@ Returns a list of objects containing replies from a given comment.
   - videoId (String) (Required) - The video ID to grab comments from
   - replyToken (String) (Required) - The reply token from a comment object of `getComments()` or the continuation string from a previous call to `getCommentReplies()`
   - setCookie (Boolean) (Optional) - The flag should be set to true when cookies are not handled by your application already (e.g. Electron)
-  - proxyData (Object) (Optional) - As seen before
+  - httpsAgent (Object) (Optional) - As seen before
 ```javascript
-const parameters = {videoId: 'someId', replyToken: 'HSDcjasgdajwSdhAsd', setCookie: true, proxyData: null};
+const parameters = {videoId: 'someId', replyToken: 'HSDcjasgdajwSdhAsd', setCookie: true, httpsAgent: null};
 ytcm.getCommentReplies(parameters).then((data) =>{
     console.log(data);
 }).catch((error)=>{

--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -8,7 +8,7 @@ function random(start, end) {
 }
 
 class HttpRequester {
-    constructor(setCookie = false, proxyData = null) {
+    constructor(setCookie = false, httpsAgent = null) {
       this.setCookie = setCookie
       this.session = axios.create({
         baseURL: baseURL,
@@ -17,18 +17,9 @@ class HttpRequester {
           'X-YouTube-Client-Name': '1',
           'X-YouTube-Client-Version': '2.20210331.06.00',
           'accept-language': 'en-US,en;q=0.5',
-        }
+        },
+        httpsAgent: httpsAgent
       })
-      if (proxyData) {
-        this.session.defaults["proxy"] = {};
-        this.session.defaults.proxy.host = proxyData.host;
-        this.session.defaults.proxy.port = proxyData.port;
-        this.session.defaults.proxy.protocol = proxyData.protocol;
-        if (proxyData.auth) {
-          this.session.defaults.auth.password = proxyData.auth.username;
-          this.session.defaults.auth.username = proxyData.auth.password;
-        }
-      }
       // NOTE: This currently provides a CONSENT cookie to
       // everyone, including non-European populations,
       // making this cookie potentially fingerprintable

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -10,7 +10,7 @@ class CommentScraper {
       let xsrf
       let continuationToken
       const sortBy = payload.sortByNewest ? 'new' : 'top'
-      const requester = new HttpRequester((payload.setCookie === true), payload.proxyData)
+      const requester = new HttpRequester((payload.setCookie === true), payload.httpsAgent)
 
       if (payload.continuation) {
         if (typeof payload.xsrf !== 'undefined') {
@@ -49,12 +49,12 @@ class CommentScraper {
       }
     }
 
-    static async getCommentReplies({videoId, replyToken, setCookie, proxyData}) {
+    static async getCommentReplies({videoId, replyToken, setCookie, httpsAgent}) {
       if (typeof videoId === 'undefined') {
         return Promise.reject('No video Id given')
       }
 
-      const requester = new HttpRequester((setCookie === true), proxyData)
+      const requester = new HttpRequester((setCookie === true), httpsAgent)
 
       const tokens = await requester.getVideoTokens(videoId, 'top')
       const xsrf = tokens.xsrf


### PR DESCRIPTION
There is an error in the line HttpRequester.js: 28:47

> TypeError: Cannot set property 'password' of undefined
> at new HttpRequester (/node_modules/yt-comment-scraper/src/HttpRequester.js:28:47)
> at Function.getComments (/node_modules/yt-comment-scraper/src/Youtube-Scraper.js:13:25)
> at channel (/controllers/youtube.controller.ts:94:26)
> at runMicrotasks ()
> at processTicksAndRejections (internal/process/task_queues.js:93:5)

My proposal is to add the option to use an HttpsAgent like this:

```
import HttpsProxyAgent from 'https-proxy-agent';
const agent = HttpsProxyAgent(proxy);

const payload = {
    videoId: video.id,
    sortByNewest: true,
    setCookie: true,
    httpsAgent: agent
}

ytcm.getComments(payload).then((data) => {
    console.log('Get comments data');
}).catch((error)=>{
    console.log(error);
});
```

I have tested it with a private proxy, and it works fine, with authentication and without authentication.