### PR TITLE
[Fix] scraping videos with no comments/disabled comments

### DIFF
--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -33,9 +33,14 @@ class CommentScraper {
       }
 
       const commentPageResponse = await requester.requestCommentsPage(commentsPayload)
-      const commentHtml = commentPageResponse.data.response.continuationContents.itemSectionContinuation
-      const commentData = (typeof commentHtml.contents !== 'undefined') ? htmlParser.parseCommentData(commentHtml.contents) : []
-      const continuation = commentHtml.continuations
+      let commentHtml = ''
+      let continuation = ''
+      let commentData = []
+      if ('response' in commentPageResponse.data) {
+        commentPageResponse.data.response.continuationContents.itemSectionContinuation
+        continuation = commentHtml.continuations
+        commentData = (typeof commentHtml?.contents !== 'undefined') ? htmlParser.parseCommentData(commentHtml.contents) : []
+      }
 
       let ctoken = null
 

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -34,12 +34,14 @@ class CommentScraper {
 
       const commentPageResponse = await requester.requestCommentsPage(commentsPayload)
       let commentHtml = ''
-      let continuation = ''
+      let continuation = undefined
       let commentData = []
-      if ('response' in commentPageResponse.data) {
-        commentPageResponse.data.response.continuationContents.itemSectionContinuation
-        continuation = commentHtml.continuations
-        commentData = (typeof commentHtml?.contents !== 'undefined') ? htmlParser.parseCommentData(commentHtml.contents) : []
+      if (commentPageResponse.data !== '') { // will be an empty string for disabled comments (ex. topics)
+        if ('response' in commentPageResponse.data) { // won't exist if no comments
+          commentPageResponse.data.response.continuationContents.itemSectionContinuation
+          continuation = commentHtml.continuations
+          commentData = (typeof commentHtml?.contents !== 'undefined') ? htmlParser.parseCommentData(commentHtml.contents) : []
+        }
       }
 
       let ctoken = null

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -40,7 +40,7 @@ class CommentScraper {
         if ('response' in commentPageResponse.data) { // won't exist if no comments
           commentPageResponse.data.response.continuationContents.itemSectionContinuation
           continuation = commentHtml.continuations
-          commentData = (typeof commentHtml?.contents !== 'undefined') ? htmlParser.parseCommentData(commentHtml.contents) : []
+          commentData = htmlParser.parseCommentData(commentHtml.contents)
         }
       }
 


### PR DESCRIPTION
https://github.com/FreeTubeApp/FreeTube/issues/1493
 https://github.com/FreeTubeApp/FreeTube/issues/1490

Youtube stopped sending the response object when there are no comments
and sends an empty string for data when comments are disabled. 