### PR TITLE
add support for extracting custom emojis from comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The data is returned as an object with a list of comment objects and a continuat
       customEmojis: Array [ // An Array of custom emojis used in the comment
         {
           text: String, // the text alias for the emoji
-          emojiThumb: Array [ // An Array of thumbnails of the custom emoji
+          emojiThumbnails: Array [ // An Array of thumbnails of the custom emoji
             {
               width: Number,
               height: Number,

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The data is returned as a list of objects (seen below).
     customEmojis: Array [ // An Array of custom emojis used in the comment
       {
         text: String, // the text alias for the emoji
-        emojiThumb: Array [ // An Array of thumbnails of the custom emoji
+        emojiThumbnails: Array [ // An Array of thumbnails of the custom emoji
           {
             width: Number,
             height: Number,

--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ The data is returned as an object with a list of comment objects and a continuat
       isVerified: Boolean,
       isOfficialArtist: Boolean,
       hasOwnerReplied: Boolean, // If the video channel replied to the comment
-      replyToken: String // The continuation token needed for getCommentReplies()
+      replyToken: String, // The continuation token needed for getCommentReplies()
+      customEmojis: Array [ // An Array of custom emojis used in the comment
+        {
+          text: String, // the text alias for the emoji
+          emojiThumb: Array [ // An Array of thumbnails of the custom emoji
+            {
+              width: Number,
+              height: Number,
+              url: String
+            }
+          ]
+        }
+      ]
     }
   ],
   continuation: String | null // The continuation token needed to get more comments from getComments()
@@ -129,7 +141,19 @@ The data is returned as a list of objects (seen below).
     isVerified: Boolean,
     isOfficialArtist: Boolean,
     hasOwnerReplied: false,
-    replyToken: null
+    replyToken: null,
+    customEmojis: Array [ // An Array of custom emojis used in the comment
+      {
+        text: String, // the text alias for the emoji
+        emojiThumb: Array [ // An Array of thumbnails of the custom emoji
+          {
+            width: Number,
+            height: Number,
+            url: String
+          }
+        ]
+      }
+    ]
   }],
   continuation: String | null // The continuation token needed (instead of replyToken) to get more replies from getCommentReplies()
 ```

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -40,7 +40,7 @@ class HtmlParser {
           text = text + content.text
         }
         if (typeof content.emoji !== 'undefined') {
-          customEmojis.push({"text":content.text,"emojiThumb":content.emoji.image.thumbnails})
+          customEmojis.push({"text":content.text,"emojiThumbnails":content.emoji.image.thumbnails})
         }
       })
 

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -48,7 +48,7 @@ class HtmlParser {
         }
         if (typeof content.emoji !== 'undefined') {
           customEmojis.push({
-            text:            content.text,
+            text: content.text,
             emojiThumbnails: content.emoji.image.thumbnails
           })
         }

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -61,7 +61,7 @@ class HtmlParser {
         replyToken: null,
         isVerified: isVerified,
         isOfficialArtist: isOfficialArtist,
-        customEmojis
+        customEmojis: customEmojis
       }
 
       if (comment.replyCount > 0) {

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -32,7 +32,7 @@ class HtmlParser {
 
       const contentText = comment.contentText.runs
 
-      let customEmojis = []
+      const customEmojis = []
       contentText.forEach((content) => {
         if (content.text.trim() === '') {
           text = text + '<br>'

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -32,11 +32,15 @@ class HtmlParser {
 
       const contentText = comment.contentText.runs
 
+      let customEmojis = []
       contentText.forEach((content) => {
         if (content.text.trim() === '') {
           text = text + '<br>'
         } else {
           text = text + content.text
+        }
+        if (typeof content.emoji !== 'undefined') {
+          customEmojis.push({"text":content.text,"emojiThumb":content.emoji.image.thumbnails})
         }
       })
 
@@ -56,7 +60,8 @@ class HtmlParser {
         edited: isEdited,
         replyToken: null,
         isVerified: isVerified,
-        isOfficialArtist: isOfficialArtist
+        isOfficialArtist: isOfficialArtist,
+        customEmojis
       }
 
       if (comment.replyCount > 0) {

--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -47,7 +47,10 @@ class HtmlParser {
           text = text + content.text
         }
         if (typeof content.emoji !== 'undefined') {
-          customEmojis.push({"text":content.text,"emojiThumbnails":content.emoji.image.thumbnails})
+          customEmojis.push({
+            text:            content.text,
+            emojiThumbnails: content.emoji.image.thumbnails
+          })
         }
       })
 

--- a/test/scraper.test.js
+++ b/test/scraper.test.js
@@ -90,4 +90,11 @@ describe('Standalone Mode: Comment Testing', () => {
             expect(data.comments[0].isOfficialArtist).toBeTruthy();
         });
     });
+
+    test('Scrape customEmojis', () => {
+        const parameters = {videoId: 'HhuHyQlFz_M', mustSetCookie: true};
+        return ytcm.getComments(parameters).then((data) => {
+            expect(data.comments[0].customEmojis[0]).toBeTruthy();
+        });
+    });
 })


### PR DESCRIPTION
I noticed an[ issue on the Invidious repo](https://github.com/iv-org/invidious/issues/2308) and noticed the same issue occurred when using freetube localApi


https://www.youtube.com/watch?v=HhuHyQlFz_M
If you look at the pinned comment on this vid you'll notice it has a custom emoji
![image](https://user-images.githubusercontent.com/78101139/131758912-3fd572c5-19e3-49f3-9da1-106713a1a073.png)
In FreeTube it looks like this
![image](https://user-images.githubusercontent.com/78101139/131758951-96f4457f-6cee-4bee-be71-e0716b6f43fd.png)
This PR will add an array that will contain object that have the text alias (ex: :_joltslove_:) and an array of thumbnails.