### PR TITLE
Fixes disabled comments sections returning error

### DIFF
--- a/src/HttpRequester.js
+++ b/src/HttpRequester.js
@@ -58,16 +58,19 @@ class HttpRequester {
   }
 
   getContinuationToken(sortByNewest) {
-    let continuation = this.cachedInitialData.match(
+    const result = this.cachedInitialData.match(
       /"itemSectionRenderer".*"token":"([^"]*)".*"targetId":"comments-section"/
-    )[1]
+    )
 
-    // Gets top comments by default, and new comments if true
-    if (sortByNewest) {
-      continuation = continuation.slice(0, 47) + "B" + continuation.substring(48)
+    if (!result) {
+      return null
     }
 
-    return continuation
+    let continuation = result[1]
+    // Gets top comments by default, and new comments if true
+    return sortByNewest 
+      ? (continuation.slice(0, 47) + "B" + continuation.substring(48))
+      : continuation
   }
 
   async requestCommentsPage(continuation) {

--- a/src/Youtube-Scraper.js
+++ b/src/Youtube-Scraper.js
@@ -39,6 +39,10 @@ class CommentScraper {
     }
 
     let token = continuation ?? requester.getContinuationToken(sortByNewest)
+    if (!token) {
+      return { comments: [], continuation: token}
+    }
+
     const commentPageResponse = await requester.requestCommentsPage(token)
     let commentHtml
     if (continuation) {


### PR DESCRIPTION
Resolves this issue: https://github.com/FreeTubeApp/FreeTube/issues/1040

Prevents the gnarly error `TypeError: Cannot read properties of null (reading '1')` on disabled comments sections.