### PR TITLE
Only package the required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "6.1.0",
   "description": "Scrapes the comments of any YouTube video without YouTube API access. Uses the default YouTube Ajax calls to get the comment data.",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "src/",
+    "index.d.ts"
+  ],
   "scripts": {
     "test": "jest --watchAll --verbose",
     "test-ci": "jest --verbose --ci"


### PR DESCRIPTION
Only package and publish the required files to the npm repository, this prevents the workflows and test files from being published. The README, LICENSE and package.json files are [always packaged](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files) so they don't need to be explicitly whitelisted.

You can test this pull request by running `npm pack` in your terminal, which packages it into a gzipped tar archive and prints the list of packaged files to your terminal.