### PR TITLE
Add support for bold, italics and strikethrough formatting

### DIFF
--- a/src/htmlParser.js
+++ b/src/htmlParser.js
@@ -41,8 +41,22 @@ class HtmlParser {
 
       const customEmojis = []
       contentText.forEach((content) => {
-        if (content.text.trim() === '') {
+        if (content.text === '\n') {
           text = text + '<br>'
+        } else if (content.bold || content.strikethrough || content.italics) {
+          let formattedText = content.text
+
+          if (content.bold) {
+            formattedText = '<b>' + formattedText + '</b>'
+          }
+          if (content.strikethrough) {
+            formattedText = '<s>' + formattedText + '</s>'
+          }
+          if (content.italics) {
+            formattedText = '<i>' + formattedText + '</i>'
+          }
+
+          text = text + formattedText
         } else {
           text = text + content.text
         }

--- a/test/scraper.test.js
+++ b/test/scraper.test.js
@@ -132,4 +132,13 @@ describe('Standalone Mode: Comment Testing', () => {
             expect(data.comments[0].customEmojis[0]).toBeTruthy();
         });
     });
+
+    test('Format text', () => {
+        const parameters = {videoId: 'OqiXFXlYFi8', mustSetCookie: true};
+        return ytcm.getComments(parameters).then((data) => {
+            const comment = data.comments.find(c => c.commentId === 'UgxTgxuBchteOmDLdGl4AaABAg');
+            expect(comment).not.toBeUndefined();
+            expect(comment.text).toBe('<b>This text will be bold</b> and <i>this will be italicized</i> and <s>this will will be crossed out</s>');
+        })
+    });
 })


### PR DESCRIPTION
**Description**
This pull request adds support for bold, italics and strikethrough formatting in comments. It also fixes text runs with only whitespace being turned into new lines e.g. `" "`.

The way this is written it should correctly format text fragments that have multiple types of formatting applied. I haven't been able to find a comment to test that though.

FreeTube PR: https://github.com/FreeTubeApp/FreeTube/pull/2475

**Screenshots (if appropriate)**
before:
![before](https://user-images.githubusercontent.com/48293849/184450009-c232f18e-6a6e-4e45-93a3-0ce645acbda0.jpg)

after:
![after](https://user-images.githubusercontent.com/48293849/184450016-9019a4fc-bac5-40bd-8a98-64bba6549373.jpg)

**Testing (for code that is not small enough to be easily understandable)**
The comments under this video are a good place to test this PR (taken from this [article](https://www.simplehelp.net/2021/08/19/how-to-format-text-in-youtube-comments-bold-italicized-or-crossed-out/))

https://www.youtube.com/watch?v=OqiXFXlYFi8

**Additional context**
I know that the `b`, `i` and `s` tags shouldn't be used anymore but it makes this code a lot simpler, the alternative would be to pass on an array of fragments to FreeTube and let FreeTube do the formatting with CSS.